### PR TITLE
GH Action (CI) fail if Trivy finds some vulnerabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,7 +346,7 @@ jobs:
           hide-progress: true
           format: 'template'
           template: '@template.tpl'
-          exit-code: '0'
+          exit-code: '1'
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,7 +372,7 @@ jobs:
         env:
           TRIVY_USERNAME: ${GITHUB_ACTOR}
           TRIVY_PASSWORD: ${{ secrets.ORGANIZATION_TOKEN }}
-      - name: Trivy template vulnerability scan CI Fail Job
+      - name: Trivy trigger to Fail the CI
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ${{ matrix.image }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,7 +346,7 @@ jobs:
           hide-progress: true
           format: 'template'
           template: '@template.tpl'
-          exit-code: '1'
+          exit-code: '0'
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,3 +372,20 @@ jobs:
         env:
           TRIVY_USERNAME: ${GITHUB_ACTOR}
           TRIVY_PASSWORD: ${{ secrets.ORGANIZATION_TOKEN }}
+      - name: Trivy template vulnerability scan CI Fail Job
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ matrix.image }}
+          scan-type: image
+          hide-progress: true
+          format: 'template'
+          template: '@template.tpl'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+          output: 'scan-results.md'
+          github-pat: ${{ secrets.ORGANIZATION_TOKEN }}
+        env:
+          TRIVY_USERNAME: ${GITHUB_ACTOR}
+          TRIVY_PASSWORD: ${{ secrets.ORGANIZATION_TOKEN }}


### PR DESCRIPTION
This change enables the CI failure in case the Trivy (Docker Image Security&Vulnerability scanner) finds some CRITICAL and HIGH vulnerabilities. 