### PR TITLE
Trivy scan for local docker images in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,44 +60,44 @@ env:
     }}
 
 jobs:
-  codacy-analysis-cli:
-    name: Codacy Analysis CLI
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'zulu'
-          cache: 'maven'
-      - name: Set up Maven
-        run: cp build.settings.xml ~/.m2/settings.xml
-      - name: Maven Build
-        run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -Ddockerfile.skip=true -Dgithub.event.release.prerelease="${{ github.event.release.prerelease }}" -B -V -U
-        env:
-          GITHUB_TOKEN: ${{ secrets.ORGANIZATION_TOKEN }}
-      - name: Run Codacy Analysis CLI
-        uses: codacy/codacy-analysis-cli-action@master
-        env:
-          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
-        with:
-          tool: spotbugs
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          upload: true
-          max-allowed-issues: 2147483647
-          skip-uncommitted-files-check: true
-          verbose: true
-        continue-on-error: true
-      - name: Run codacy-coverage-reporter
-        uses: codacy/codacy-coverage-reporter-action@v1.3.0
-        with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-        continue-on-error: true
+  # codacy-analysis-cli:
+  #   name: Codacy Analysis CLI
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+  #         fetch-tags: true
+  #     - name: Set up JDK
+  #       uses: actions/setup-java@v4
+  #       with:
+  #         java-version: '17'
+  #         distribution: 'zulu'
+  #         cache: 'maven'
+  #     - name: Set up Maven
+  #       run: cp build.settings.xml ~/.m2/settings.xml
+  #     - name: Maven Build
+  #       run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -Ddockerfile.skip=true -Dgithub.event.release.prerelease="${{ github.event.release.prerelease }}" -B -V -U
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.ORGANIZATION_TOKEN }}
+  #     - name: Run Codacy Analysis CLI
+  #       uses: codacy/codacy-analysis-cli-action@master
+  #       env:
+  #         CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+  #       with:
+  #         tool: spotbugs
+  #         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+  #         upload: true
+  #         max-allowed-issues: 2147483647
+  #         skip-uncommitted-files-check: true
+  #         verbose: true
+  #       continue-on-error: true
+  #     - name: Run codacy-coverage-reporter
+  #       uses: codacy/codacy-coverage-reporter-action@v1.3.0
+  #       with:
+  #         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+  #       continue-on-error: true
 
   build:
     name: Build (${{ matrix.arch }}) and mvn verify ${{ matrix.mvn-verify-opts }}
@@ -136,8 +136,14 @@ jobs:
       - name: Prepare TEST_IMAGE_TAG env
         run: |
           echo TEST_IMAGE_TAG=$(echo ${VERSION} | sed 's/\//-/g') >> $GITHUB_ENV
-      - name: Build Docker images
+      - name: Build and Scan Docker images
         run: |
+          echo "Install Trivy scanner for Docker Image Security scanning"
+          sudo apt-get update
+          sudo apt-get install -y wget
+          wget https://github.com/aquasecurity/trivy/releases/download/v0.40.0/trivy_0.40.0_Linux-64bit.deb
+          sudo dpkg -i trivy_0.40.0_Linux-64bit.deb
+
           for directory in `find * -maxdepth 10 -mindepth 0 -type f -name 'Dockerfile' | xargs dirname`
           do
             echo Run docker buildx build for $directory
@@ -148,7 +154,9 @@ jobs:
             fi
             docker buildx build --load --platform ${{ matrix.arch }} \
             -t ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }} \
-            $directory
+            $directory 
+            echo "Running Trivy scanner for ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}"
+            trivy image --format table --exit-code 0 --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}
           done
       - name: Show Docker images
         run: docker images | grep ${GITHUB_REPOSITORY} || (echo Docker images not found && exit 1)
@@ -171,7 +179,6 @@ jobs:
   push:
     outputs:
      images: ${{ steps.pushDockerImages.outputs.images }}
-     image_ids: ${{ steps.pushDockerImages.outputs.image_ids }}
     if: >
       inputs.force-publish == true 
       || (github.event_name == 'push' && (github.ref_name == 'develop' || github.ref_name == 'master'))
@@ -245,27 +252,7 @@ jobs:
           echo ${IMAGES[@]}
           echo "####################################"
           echo $json_array
-          # Show docker images
-          docker images
-          # Show docker image IDs
-          image_ids=($(docker images | grep ghcr.io | awk '{print $3}'))
-          echo $image_ids
-          # Convert the array to a JSON string for Docker image ID
-          json_array_id="["
-          for element_id in "${image_ids[@]}"; do
-              json_array_id+="$element_id,"
-          done
-          json_array_id="${json_array_id%,}]"
-          echo "::set-output name=img_id::$json_array_id"
 
-          VERSION=$(date +%Y%m%d%H%M%S)
-          echo "image_ids=$json_array_id" >> $GITHUB_OUTPUT
-          echo "####################################"
-          echo $VERSION
-          echo "####################################"
-          echo ${image_ids[@]}
-          echo "####################################"
-          echo $json_array_id
       - name: Package and publish to helm registry
         run: |
           for directory in `find ./charts -type d -maxdepth 1 -mindepth 1`
@@ -364,7 +351,6 @@ jobs:
       fail-fast: false
       matrix:
         image: ${{ fromJson(needs.push.outputs.images) }}
-        image_ids: ${{ fromJson(needs.push.outputs.image_ids) }}
     runs-on: ubuntu-latest
     steps:
       - name: jobName
@@ -376,7 +362,6 @@ jobs:
       - name: Check image list
         run:
           echo ${{ fromJson(needs.push.outputs.images) }}
-          echo ${{ fromJson(needs.push.outputs.image_ids) }}
       - name: Make trivy template file with heredoc
         run: |
           cat << 'EOF' > template.tpl 
@@ -407,7 +392,7 @@ jobs:
       - name: Trivy template vulnerability scan
         uses: aquasecurity/trivy-action@0.24.0
         with:
-          image-ref: ${{ matrix.image_ids }}
+          image-ref: ${{ matrix.image }}
           scan-type: image
           timeout: 10m
           hide-progress: true
@@ -427,7 +412,7 @@ jobs:
       - name: Trivy vulnerability scanner table format 
         uses: aquasecurity/trivy-action@0.24.0
         with:
-          image-ref: ${{ matrix.image_ids }}
+          image-ref: ${{ matrix.image }}
           scan-type: image
           timeout: 10m
           format: 'table'
@@ -443,7 +428,7 @@ jobs:
       - name: Trivy trigger to Fail the CI
         uses: aquasecurity/trivy-action@0.24.0
         with:
-          image-ref: ${{ matrix.image_ids }}
+          image-ref: ${{ matrix.image }}
           scan-type: image
           timeout: 10m
           hide-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
             -t ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }} \
             $directory 
             echo "Running Trivy scanner for ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}"
-            trivy image --format template --template @template.tpl --exit-code 1 --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH --output scan-results.md --timeout 10m ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}
+            trivy image --format template --template @template.tpl --exit-code 0 --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH --output scan-results.md --timeout 10m ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}
             echo "## Docker Image: ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}" >> $GITHUB_STEP_SUMMARY
             cat scan-results.md >> $GITHUB_STEP_SUMMARY
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,19 @@ jobs:
           done
       - name: Show Docker images
         run: docker images | grep ${GITHUB_REPOSITORY} || (echo Docker images not found && exit 1)
+      - name: Scan Docker images and fail CI in case it detects any vulnerabilities
+        run: |
+          for directory in `find * -maxdepth 10 -mindepth 0 -type f -name 'Dockerfile' | xargs dirname`
+          do
+            echo Run docker buildx build for $directory
+            if [[ $directory == '.' ]]; then
+              image=${{ github.event.repository.name }}
+            else
+              image=$directory
+            fi
+            echo "Running Trivy scanner for ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}"
+            trivy image --format template --template @template.tpl --exit-code 1 --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH --output scan-results.md --timeout 10m ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}
+          done
       - name: Maven Verify
         if: inputs.tests == true && github.event_name != 'release'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
             -t ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }} \
             $directory 
             echo "Running Trivy scanner for ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}"
-            trivy image --format table --exit-code 0 --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}
+            trivy image --format table --exit-code 1 --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}
           done
       - name: Show Docker images
         run: docker images | grep ${GITHUB_REPOSITORY} || (echo Docker images not found && exit 1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
             -t ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }} \
             $directory 
             echo "Running Trivy scanner for ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}"
-            trivy image --format template --template template.tpl --exit-code 0 --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH --output scan-results.md --timeout 10m ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}
+            trivy image --format template --template @template.tpl --exit-code 0 --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH --output scan-results.md --timeout 10m ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}
             cat scan-results.md >> $GITHUB_STEP_SUMMARY
           done
       - name: Show Docker images

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,10 @@ jobs:
               {{- end }}
             {{- end }}
           {{- end }}
+          
+          | Docker Image Reference | {{ .ArtifactName }} |
+          | Docker Image ID        | {{ .ArtifactID }} |
+          | - | - |
 
           | VulnerabilityID | Severity |
           | - | - |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,44 +60,44 @@ env:
     }}
 
 jobs:
-  # codacy-analysis-cli:
-  #   name: Codacy Analysis CLI
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
-  #         fetch-tags: true
-  #     - name: Set up JDK
-  #       uses: actions/setup-java@v4
-  #       with:
-  #         java-version: '17'
-  #         distribution: 'zulu'
-  #         cache: 'maven'
-  #     - name: Set up Maven
-  #       run: cp build.settings.xml ~/.m2/settings.xml
-  #     - name: Maven Build
-  #       run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -Ddockerfile.skip=true -Dgithub.event.release.prerelease="${{ github.event.release.prerelease }}" -B -V -U
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.ORGANIZATION_TOKEN }}
-  #     - name: Run Codacy Analysis CLI
-  #       uses: codacy/codacy-analysis-cli-action@master
-  #       env:
-  #         CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
-  #       with:
-  #         tool: spotbugs
-  #         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-  #         upload: true
-  #         max-allowed-issues: 2147483647
-  #         skip-uncommitted-files-check: true
-  #         verbose: true
-  #       continue-on-error: true
-  #     - name: Run codacy-coverage-reporter
-  #       uses: codacy/codacy-coverage-reporter-action@v1.3.0
-  #       with:
-  #         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-  #       continue-on-error: true
+  codacy-analysis-cli:
+    name: Codacy Analysis CLI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+          cache: 'maven'
+      - name: Set up Maven
+        run: cp build.settings.xml ~/.m2/settings.xml
+      - name: Maven Build
+        run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -Ddockerfile.skip=true -Dgithub.event.release.prerelease="${{ github.event.release.prerelease }}" -B -V -U
+        env:
+          GITHUB_TOKEN: ${{ secrets.ORGANIZATION_TOKEN }}
+      - name: Run Codacy Analysis CLI
+        uses: codacy/codacy-analysis-cli-action@master
+        env:
+          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        with:
+          tool: spotbugs
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          upload: true
+          max-allowed-issues: 2147483647
+          skip-uncommitted-files-check: true
+          verbose: true
+        continue-on-error: true
+      - name: Run codacy-coverage-reporter
+        uses: codacy/codacy-coverage-reporter-action@v1.3.0
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        continue-on-error: true
 
   build:
     name: Build (${{ matrix.arch }}) and mvn verify ${{ matrix.mvn-verify-opts }}
@@ -109,7 +109,7 @@ jobs:
         mvn-verify-opts: ${{ fromJson(inputs.mvn-verify-opts) }}
     steps:
       - name: jobName
-        run: echo '# Build 🚀' >> $GITHUB_STEP_SUMMARY
+        run: echo '# Build and Scan 🚀' >> $GITHUB_STEP_SUMMARY
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -163,13 +163,13 @@ jobs:
           | Total Critical | {{ $critical }} |
           | Total High | {{ $high }} |
           EOF
-      - name: Build and Scan Docker images
+      - name: Build and Scan Docker images with Trivy
         run: |
           echo "Install Trivy scanner for Docker Image Security scanning"
           sudo apt-get update
           sudo apt-get install -y wget > /dev/null 2>&1
-          wget -q https://github.com/aquasecurity/trivy/releases/download/v0.40.0/trivy_0.40.0_Linux-64bit.deb
-          sudo dpkg -i trivy_0.40.0_Linux-64bit.deb > /dev/null 2>&1
+          wget -q https://github.com/aquasecurity/trivy/releases/download/v0.55.0/trivy_0.55.0_Linux-64bit.deb
+          sudo dpkg -i trivy_0.55.0_Linux-64bit.deb > /dev/null 2>&1
 
           for directory in `find * -maxdepth 10 -mindepth 0 -type f -name 'Dockerfile' | xargs dirname`
           do
@@ -382,107 +382,3 @@ jobs:
         run: |
           echo Remove git tag
           git push origin :refs/tags/${{ github.event.release.tag_name }}
-  scan:
-    if: >
-      inputs.force-publish == true 
-      || (github.event_name == 'push' && (github.ref_name == 'develop' || github.ref_name == 'master'))
-      || github.event_name == 'release' 
-    name: Scan ${{ matrix.image }}
-    needs: push
-    strategy:
-      fail-fast: false
-      matrix:
-        image: ${{ fromJson(needs.push.outputs.images) }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: jobName
-        run: echo '# Scan 🚀' >> $GITHUB_STEP_SUMMARY
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Login to Docker
-        run: docker login ghcr.io -u ${GITHUB_ACTOR} --password ${{ secrets.ORGANIZATION_TOKEN }}
-      - name: Check image list
-        run:
-          echo ${{ fromJson(needs.push.outputs.images) }}
-      - name: Make trivy template file with heredoc
-        run: |
-          cat << 'EOF' > template.tpl 
-          {{- $critical := 0 }}
-          {{- $high := 0 }}
-
-          {{- range . }}
-            {{- range .Vulnerabilities }}
-              {{- if  eq .Severity "CRITICAL" }}
-                {{- $critical = add $critical 1 }}
-              {{- end }}
-              {{- if  eq .Severity "HIGH" }}
-                {{- $high = add $high 1 }}
-              {{- end }}
-            {{- end }}
-          {{- end }}
-
-          | VulnerabilityID | Severity |
-          | - | - |
-          {{- range .}}
-            {{- range .Vulnerabilities }}
-          | {{ .VulnerabilityID }} |  {{ .Severity }} |
-            {{- end }}
-          {{- end }}
-          | Total Critical | {{ $critical }} |
-          | Total High | {{ $high }} |
-          EOF
-      - name: Trivy template vulnerability scan
-        uses: aquasecurity/trivy-action@0.24.0
-        with:
-          image-ref: ${{ matrix.image }}
-          scan-type: image
-          timeout: 10m
-          hide-progress: true
-          format: 'template'
-          template: '@template.tpl'
-          exit-code: '0'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
-          output: 'scan-results.md'
-          github-pat: ${{ secrets.ORGANIZATION_TOKEN }}
-        env:
-          TRIVY_USERNAME: ${GITHUB_ACTOR}
-          TRIVY_PASSWORD: ${{ secrets.ORGANIZATION_TOKEN }}
-      - name: Trivy output scan results
-        run: cat scan-results.md >> $GITHUB_STEP_SUMMARY
-      - name: Trivy vulnerability scanner table format 
-        uses: aquasecurity/trivy-action@0.24.0
-        with:
-          image-ref: ${{ matrix.image }}
-          scan-type: image
-          timeout: 10m
-          format: 'table'
-          exit-code: "${{ inputs.fail-on-vulnerability-issues }}"
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
-          output: 'dependency-results.sbom.json'
-          github-pat: ${{ secrets.ORGANIZATION_TOKEN }}
-        env:
-          TRIVY_USERNAME: ${GITHUB_ACTOR}
-          TRIVY_PASSWORD: ${{ secrets.ORGANIZATION_TOKEN }}
-      - name: Trivy trigger to Fail the CI
-        uses: aquasecurity/trivy-action@0.24.0
-        with:
-          image-ref: ${{ matrix.image }}
-          scan-type: image
-          timeout: 10m
-          hide-progress: true
-          format: 'template'
-          template: '@template.tpl'
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          scanners: 'vuln'
-          severity: 'CRITICAL,HIGH'
-          output: 'scan-results.md'
-          github-pat: ${{ secrets.ORGANIZATION_TOKEN }}
-        env:
-          TRIVY_USERNAME: ${GITHUB_ACTOR}
-          TRIVY_PASSWORD: ${{ secrets.ORGANIZATION_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,14 @@ jobs:
           {{- $critical := 0 }}
           {{- $high := 0 }}
 
+          {{- $artifact := index . 0 }}
+          
+          | Docker Image Reference | {{ $artifact.ArtifactName }} |
+          | Docker Image ID        | {{ $artifact.ArtifactID }} |
+          | - | - |
+
+          | VulnerabilityID | Severity |
+          | - | - |
           {{- range . }}
             {{- range .Vulnerabilities }}
               {{- if  eq .Severity "CRITICAL" }}
@@ -150,22 +158,13 @@ jobs:
               {{- if  eq .Severity "HIGH" }}
                 {{- $high = add $high 1 }}
               {{- end }}
+              | {{ .VulnerabilityID }} |  {{ .Severity }} |
             {{- end }}
           {{- end }}
-          
-          | Docker Image Reference | {{ .ArtifactName }} |
-          | Docker Image ID        | {{ .ArtifactID }} |
-          | - | - |
 
-          | VulnerabilityID | Severity |
-          | - | - |
-          {{- range .}}
-            {{- range .Vulnerabilities }}
-          | {{ .VulnerabilityID }} |  {{ .Severity }} |
-            {{- end }}
-          {{- end }}
           | Total Critical | {{ $critical }} |
           | Total High | {{ $high }} |
+          
           EOF
       - name: Build and Scan Docker images
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
           echo "Install Trivy scanner for Docker Image Security scanning"
           sudo apt-get update
           sudo apt-get install -y wget > /dev/null 2>&1
-          wget https://github.com/aquasecurity/trivy/releases/download/v0.40.0/trivy_0.40.0_Linux-64bit.deb
+          wget -q https://github.com/aquasecurity/trivy/releases/download/v0.40.0/trivy_0.40.0_Linux-64bit.deb
           sudo dpkg -i trivy_0.40.0_Linux-64bit.deb > /dev/null 2>&1
 
           for directory in `find * -maxdepth 10 -mindepth 0 -type f -name 'Dockerfile' | xargs dirname`
@@ -183,27 +183,12 @@ jobs:
             -t ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }} \
             $directory 
             echo "Running Trivy scanner for ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}"
-            trivy image --format template --template @template.tpl --exit-code 0 --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH --output scan-results.md --timeout 10m ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}
+            trivy image --format template --template @template.tpl --exit-code 1 --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH --output scan-results.md --timeout 10m ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}
             echo "## Docker Image: ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}" >> $GITHUB_STEP_SUMMARY
             cat scan-results.md >> $GITHUB_STEP_SUMMARY
           done
       - name: Show Docker images
         run: docker images | grep ${GITHUB_REPOSITORY} || (echo Docker images not found && exit 1)
-      - name: Scan Docker images and fail CI in case it detects any vulnerabilities
-        run: |
-          for directory in `find * -maxdepth 10 -mindepth 0 -type f -name 'Dockerfile' | xargs dirname`
-          do
-            echo Run docker buildx build for $directory
-            if [[ $directory == '.' ]]; then
-              image=${{ github.event.repository.name }}
-            else
-              image=$directory
-            fi
-            echo "Running Trivy scanner for ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}"
-            trivy image --format template --template @template.tpl --exit-code 1 --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH --output scan-results.md --timeout 10m ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}
-            echo "## Docker Image: ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}" >> $GITHUB_STEP_SUMMARY
-            cat scan-results.md >> $GITHUB_STEP_SUMMARY
-          done
       - name: Maven Verify
         if: inputs.tests == true && github.event_name != 'release'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,12 +142,6 @@ jobs:
           {{- $critical := 0 }}
           {{- $high := 0 }}
 
-          {{- $artifact := index . 0 }}
-          
-          | Docker Image Reference | {{ $artifact.ArtifactName }} |
-          | Docker Image ID        | {{ $artifact.ArtifactID }} |
-          | - | - |
-
           | VulnerabilityID | Severity |
           | - | - |
           {{- range . }}
@@ -164,7 +158,7 @@ jobs:
 
           | Total Critical | {{ $critical }} |
           | Total High | {{ $high }} |
-          
+
           EOF
       - name: Build and Scan Docker images
         run: |
@@ -187,6 +181,7 @@ jobs:
             $directory 
             echo "Running Trivy scanner for ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}"
             trivy image --format template --template @template.tpl --exit-code 0 --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH --output scan-results.md --timeout 10m ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}
+            echo "## Docker Image: ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}" >> $GITHUB_STEP_SUMMARY
             cat scan-results.md >> $GITHUB_STEP_SUMMARY
           done
       - name: Show Docker images

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,8 +142,6 @@ jobs:
           {{- $critical := 0 }}
           {{- $high := 0 }}
 
-          | VulnerabilityID | Severity |
-          | - | - |
           {{- range . }}
             {{- range .Vulnerabilities }}
               {{- if  eq .Severity "CRITICAL" }}
@@ -152,13 +150,18 @@ jobs:
               {{- if  eq .Severity "HIGH" }}
                 {{- $high = add $high 1 }}
               {{- end }}
-              | {{ .VulnerabilityID }} |  {{ .Severity }} |
             {{- end }}
           {{- end }}
 
+          | VulnerabilityID | Severity |
+          | - | - |
+          {{- range .}}
+            {{- range .Vulnerabilities }}
+          | {{ .VulnerabilityID }} |  {{ .Severity }} |
+            {{- end }}
+          {{- end }}
           | Total Critical | {{ $critical }} |
           | Total High | {{ $high }} |
-
           EOF
       - name: Build and Scan Docker images
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Prepare TEST_IMAGE_TAG env
         run: |
           echo TEST_IMAGE_TAG=$(echo ${VERSION} | sed 's/\//-/g') >> $GITHUB_ENV
-      - name: Make trivy template file with heredoc
+      - name: Make Trivy template file with heredoc
         run: |
           cat << 'EOF' > template.tpl 
           {{- $critical := 0 }}
@@ -167,9 +167,9 @@ jobs:
         run: |
           echo "Install Trivy scanner for Docker Image Security scanning"
           sudo apt-get update
-          sudo apt-get install -y wget
+          sudo apt-get install -y wget > /dev/null 2>&1
           wget https://github.com/aquasecurity/trivy/releases/download/v0.40.0/trivy_0.40.0_Linux-64bit.deb
-          sudo dpkg -i trivy_0.40.0_Linux-64bit.deb
+          sudo dpkg -i trivy_0.40.0_Linux-64bit.deb > /dev/null 2>&1
 
           for directory in `find * -maxdepth 10 -mindepth 0 -type f -name 'Dockerfile' | xargs dirname`
           do
@@ -189,6 +189,21 @@ jobs:
           done
       - name: Show Docker images
         run: docker images | grep ${GITHUB_REPOSITORY} || (echo Docker images not found && exit 1)
+      - name: Scan Docker images and fail CI in case it detects any vulnerabilities
+        run: |
+          for directory in `find * -maxdepth 10 -mindepth 0 -type f -name 'Dockerfile' | xargs dirname`
+          do
+            echo Run docker buildx build for $directory
+            if [[ $directory == '.' ]]; then
+              image=${{ github.event.repository.name }}
+            else
+              image=$directory
+            fi
+            echo "Running Trivy scanner for ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}"
+            trivy image --format template --template @template.tpl --exit-code 1 --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH --output scan-results.md --timeout 10m ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}
+            echo "## Docker Image: ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}" >> $GITHUB_STEP_SUMMARY
+            cat scan-results.md >> $GITHUB_STEP_SUMMARY
+          done
       - name: Maven Verify
         if: inputs.tests == true && github.event_name != 'release'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,7 @@ jobs:
   push:
     outputs:
      images: ${{ steps.pushDockerImages.outputs.images }}
+     image_ids: ${{ steps.pushDockerImages.outputs.image_ids }}
     if: >
       inputs.force-publish == true 
       || (github.event_name == 'push' && (github.ref_name == 'develop' || github.ref_name == 'master'))
@@ -244,6 +245,27 @@ jobs:
           echo ${IMAGES[@]}
           echo "####################################"
           echo $json_array
+          # Show docker images
+          docker images
+          # Show docker image IDs
+          image_ids=($(docker images | grep ghcr.io | awk '{print $3}'))
+          echo $image_ids
+          # Convert the array to a JSON string for Docker image ID
+          json_array_id="["
+          for element_id in "${image_ids[@]}"; do
+              json_array_id+="$element_id,"
+          done
+          json_array_id="${json_array_id%,}]"
+          echo "::set-output name=img_id::$json_array_id"
+
+          VERSION=$(date +%Y%m%d%H%M%S)
+          echo "image_ids=$json_array_id" >> $GITHUB_OUTPUT
+          echo "####################################"
+          echo $VERSION
+          echo "####################################"
+          echo ${image_ids[@]}
+          echo "####################################"
+          echo $json_array_id
       - name: Package and publish to helm registry
         run: |
           for directory in `find ./charts -type d -maxdepth 1 -mindepth 1`
@@ -342,6 +364,7 @@ jobs:
       fail-fast: false
       matrix:
         image: ${{ fromJson(needs.push.outputs.images) }}
+        image_ids: ${{ fromJson(needs.push.outputs.image_ids) }}
     runs-on: ubuntu-latest
     steps:
       - name: jobName
@@ -353,6 +376,7 @@ jobs:
       - name: Check image list
         run:
           echo ${{ fromJson(needs.push.outputs.images) }}
+          echo ${{ fromJson(needs.push.outputs.image_ids) }}
       - name: Make trivy template file with heredoc
         run: |
           cat << 'EOF' > template.tpl 
@@ -383,7 +407,7 @@ jobs:
       - name: Trivy template vulnerability scan
         uses: aquasecurity/trivy-action@0.24.0
         with:
-          image-ref: ${{ matrix.image }}
+          image-ref: ${{ matrix.image_ids }}
           scan-type: image
           timeout: 10m
           hide-progress: true
@@ -403,7 +427,7 @@ jobs:
       - name: Trivy vulnerability scanner table format 
         uses: aquasecurity/trivy-action@0.24.0
         with:
-          image-ref: ${{ matrix.image }}
+          image-ref: ${{ matrix.image_ids }}
           scan-type: image
           timeout: 10m
           format: 'table'
@@ -419,7 +443,7 @@ jobs:
       - name: Trivy trigger to Fail the CI
         uses: aquasecurity/trivy-action@0.24.0
         with:
-          image-ref: ${{ matrix.image }}
+          image-ref: ${{ matrix.image_ids }}
           scan-type: image
           timeout: 10m
           hide-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,33 @@ jobs:
       - name: Prepare TEST_IMAGE_TAG env
         run: |
           echo TEST_IMAGE_TAG=$(echo ${VERSION} | sed 's/\//-/g') >> $GITHUB_ENV
+      - name: Make trivy template file with heredoc
+        run: |
+          cat << 'EOF' > template.tpl 
+          {{- $critical := 0 }}
+          {{- $high := 0 }}
+
+          {{- range . }}
+            {{- range .Vulnerabilities }}
+              {{- if  eq .Severity "CRITICAL" }}
+                {{- $critical = add $critical 1 }}
+              {{- end }}
+              {{- if  eq .Severity "HIGH" }}
+                {{- $high = add $high 1 }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
+
+          | VulnerabilityID | Severity |
+          | - | - |
+          {{- range .}}
+            {{- range .Vulnerabilities }}
+          | {{ .VulnerabilityID }} |  {{ .Severity }} |
+            {{- end }}
+          {{- end }}
+          | Total Critical | {{ $critical }} |
+          | Total High | {{ $high }} |
+          EOF
       - name: Build and Scan Docker images
         run: |
           echo "Install Trivy scanner for Docker Image Security scanning"
@@ -156,7 +183,8 @@ jobs:
             -t ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }} \
             $directory 
             echo "Running Trivy scanner for ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}"
-            trivy image --format table --exit-code 1 --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}
+            trivy image --format template --template template.tpl --exit-code 0 --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH --output scan-results.md --timeout 10m ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.TEST_IMAGE_TAG }}
+            cat scan-results.md >> $GITHUB_STEP_SUMMARY
           done
       - name: Show Docker images
         run: docker images | grep ${GITHUB_REPOSITORY} || (echo Docker images not found && exit 1)


### PR DESCRIPTION
Scan docker images before pushing them to the GitHub Docker container registry. 
Run the security scan for every branch, not just the develop, master, and release tags.
More details here:
Issue: https://github.com/exberry-io/infrastructure/issues/826
