### PR TITLE
Disable temporarily Trivy Jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,7 @@ jobs:
           done
         env:
           GITHUB_TOKEN: ${{ secrets.ORGANIZATION_TOKEN }}
+        continue-on-error: true
       - name: Show Docker images
         run: docker images | grep ${GITHUB_REPOSITORY} || (echo Docker images not found && exit 1)
       - name: Scan Docker images and fail CI in case it detects any vulnerabilities
@@ -280,6 +281,7 @@ jobs:
           done
         env:
           GITHUB_TOKEN: ${{ secrets.ORGANIZATION_TOKEN }}
+        continue-on-error: true
 
   push:
     outputs:


### PR DESCRIPTION
Due to the annoying errors in CI, caused by downloading Trivy DB with the output:
```
2024-09-23T10:01:07Z	FATAL	Fatal error	image scan error: scan error: scan failed: failed analysis: analyze error: pipeline error: failed to analyze layer (sha256:d32e9b296735db3d72d5d7270744387d92d7cb227cf987e68d3bf71bea12614c): post analysis error: post analysis error: Unable to initialize the Java DB: Java DB update failed: DB download error: OCI repository error: 1 error occurred:
	* GET https://ghcr.io/v2/aquasecurity/trivy-java-db/manifests/1: TOOMANYREQUESTS: retry-after: 409.215µs, allowed: 44000/minute
```
The reason is the rate limit for GitHub registry. 