### PR TITLE
Add midnight workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,7 +462,9 @@ jobs:
         with:
           github-token: ${{ secrets.ORGANIZATION_TOKEN }}
           script: |
-            const issueTitle = 'Scheduled Build Fail';
+            const repoName = '${{ github.repository }}';
+            const repoShortName = repoName.split('/')[1];
+            const issueTitle = `Scheduled Build Fail (${repoShortName})`;
             const issueBody = `Link: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
             
             // Set the owner and repo to exberry-io/docs
@@ -488,9 +490,9 @@ jobs:
                 body: issueBody,
                 labels: ['Bug'],
               });
-              console.log('Created a new issue for the failed scheduled build.');
+              console.log('New issue is created for the failed scheduled build');
             } else {
-              console.log('An open issue for the failed scheduled build already exists.');
+              console.log('Open issue for the failed scheduled build already exists');
             }
 
   close_issue:
@@ -504,8 +506,10 @@ jobs:
         with:
           github-token: ${{ secrets.ORGANIZATION_TOKEN }}
           script: |
-            const issueTitle = 'Scheduled Build Fail';
-            const closeComment = `Closed due to success build`;
+            const repoName = '${{ github.repository }}';
+            const repoShortName = repoName.split('/')[1];
+            const issueTitle = `Scheduled Build Fail (${repoShortName})`;
+            const closeComment = `Closed due to success build: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
 
             // Set the owner and repo to exberry-io/docs
             const owner = 'exberry-io';
@@ -521,6 +525,7 @@ jobs:
             if (issues.length === 0) {
               console.log('No open issues to close');
             } else {
+              let issueClosed = false;
               for (const issue of issues) {
                 if (issue.title === issueTitle) {
                   // Add a comment to the issue
@@ -538,6 +543,11 @@ jobs:
                     state: 'closed',
                   });
                   console.log(`Closed issue #${issue.number}`);
+                  issueClosed = true;
                 }
+              }
+            
+              if (!issueClosed) {
+                console.log('No issues found to close');
               }
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -450,7 +450,6 @@ jobs:
           echo Remove git tag
           git push origin :refs/tags/${{ github.event.release.tag_name }}
 
-
   notify_failure:
     name: Create Issue on Failure
     if: ${{ failure() && github.event_name == 'schedule' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,8 @@ env:
       inputs.version && inputs.version 
       || (github.event_name == 'push' || github.event_name == 'release') && github.ref_name 
       || (github.event_name == 'pull_request') && github.head_ref 
-      || 'latest' 
+      || (github.event_name == 'schedule') && format('schedule-build-{0}', github.run_id)
+      || 'latest'
     }}
 
 jobs:
@@ -286,9 +287,9 @@ jobs:
 
   push:
     outputs:
-     images: ${{ steps.pushDockerImages.outputs.images }}
+      images: ${{ steps.pushDockerImages.outputs.images }}
     if: >
-      inputs.force-publish == true 
+      (github.event_name != 'schedule' && inputs.force-publish == true)
       || (github.event_name == 'push' && (github.ref_name == 'develop' || github.ref_name == 'master'))
       || github.event_name == 'release'
     name: Push artifacts
@@ -393,58 +394,150 @@ jobs:
         with:
           project_id: '${{ vars.GCP_DEB_REGISTRY_PROJECT }}'
           credentials_json: '${{ secrets.GCP_DEB_REGISTRY_CREDENTIALS}}'
-    
+
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v2'
         with:
           version: '>= 363.0.0'
-  
+
       - name: Build .deb packages and Push to Google Artifactory DEB Registry
         run: |
-            for directory in `find * -maxdepth 10 -mindepth 0 -type f -name 'Dockerfile' | xargs dirname`
-            do
-              echo Run package build for $directory
-              if [[ $directory == '.' ]]; then
-                package=${{ github.event.repository.name }}
-              else
-                package=$directory
-              fi
-              export DIRECTORY=$directory
-              echo "DIRECTORY<<EOF" >> ${GITHUB_ENV}
-              echo "${DIRECTORY}" >> ${GITHUB_ENV}
-              echo "EOF" >> ${GITHUB_ENV}
-              if [[ "${{ env.VERSION }}" == *develop* || "${{ env.VERSION }}" == *master* || "${{ env.VERSION }}" != [0-9]* ]]; then
-                 export VERSION=1.0-$(git rev-parse --abbrev-ref HEAD)-$(git describe --tags --abbrev=1 2>/dev/null)-${GITHUB_RUN_ATTEMPT}
-              else
-                 export VERSION=${{ env.VERSION }}-${GITHUB_RUN_ATTEMPT}
-              fi
-              echo "VERSION<<EOF" >> ${GITHUB_ENV}
-              echo "${VERSION}" >> ${GITHUB_ENV}
-              echo "EOF" >> ${GITHUB_ENV}
-              echo Release package version $VERSION
-              if [ -f $directory/src/deb/build-deb.sh ]; then
-                  cd $directory 
-                  # change the DEB SHA ENV value in default-env file & make backup
-                  sed -i.bak 's/SHA=.*/SHA='${{ github.sha }}'/g' ./src/deb/templates/default-env
-                  source ./src/deb/build-deb.sh
-                  PACKAGE_NAME=./target/${SERVICE_NAME}-${VERSION}.deb
-                  echo push to Google Artifactory Debian Registry $DEB_REGISTRY
-                  gcloud artifacts apt upload $DEB_REGISTRY --location=$REGISTRY_LOCATION --source=$PACKAGE_NAME
-                  # revert changes of the DEB SHA ENV value & remove backup file
-                  rm ./src/deb/templates/default-env
-                  mv ./src/deb/templates/default-env.bak ./src/deb/templates/default-env
-                  cd ..
-              else
-                 echo "The file $directory/src/deb/build-deb.sh does not exist in $directory. Skip it."
-              fi
-            done
+          for directory in `find * -maxdepth 10 -mindepth 0 -type f -name 'Dockerfile' | xargs dirname`
+          do
+            echo Run package build for $directory
+            if [[ $directory == '.' ]]; then
+              package=${{ github.event.repository.name }}
+            else
+              package=$directory
+            fi
+            export DIRECTORY=$directory
+            echo "DIRECTORY<<EOF" >> ${GITHUB_ENV}
+            echo "${DIRECTORY}" >> ${GITHUB_ENV}
+            echo "EOF" >> ${GITHUB_ENV}
+            if [[ "${{ env.VERSION }}" == *develop* || "${{ env.VERSION }}" == *master* || "${{ env.VERSION }}" != [0-9]* ]]; then
+               export VERSION=1.0-$(git rev-parse --abbrev-ref HEAD)-$(git describe --tags --abbrev=1 2>/dev/null)-${GITHUB_RUN_ATTEMPT}
+            else
+               export VERSION=${{ env.VERSION }}-${GITHUB_RUN_ATTEMPT}
+            fi
+            echo "VERSION<<EOF" >> ${GITHUB_ENV}
+            echo "${VERSION}" >> ${GITHUB_ENV}
+            echo "EOF" >> ${GITHUB_ENV}
+            echo Release package version $VERSION
+            if [ -f $directory/src/deb/build-deb.sh ]; then
+                cd $directory 
+                # change the DEB SHA ENV value in default-env file & make backup
+                sed -i.bak 's/SHA=.*/SHA='${{ github.sha }}'/g' ./src/deb/templates/default-env
+                source ./src/deb/build-deb.sh
+                PACKAGE_NAME=./target/${SERVICE_NAME}-${VERSION}.deb
+                echo push to Google Artifactory Debian Registry $DEB_REGISTRY
+                gcloud artifacts apt upload $DEB_REGISTRY --location=$REGISTRY_LOCATION --source=$PACKAGE_NAME
+                # revert changes of the DEB SHA ENV value & remove backup file
+                rm ./src/deb/templates/default-env
+                mv ./src/deb/templates/default-env.bak ./src/deb/templates/default-env
+                cd ..
+            else
+               echo "The file $directory/src/deb/build-deb.sh does not exist in $directory. Skip it."
+            fi
+          done
         env:
           DEB_REGISTRY: ${{ vars.GCP_DEB_REGISTRY }}
           REGISTRY_LOCATION: ${{ vars.GCP_REGISTRY_LOCATION }}
           DIRECTORY: ${{ env.DIRECTORY }}
-  
+
       - name: Rollback release
         if: failure() && github.event_name == 'release'
         run: |
           echo Remove git tag
           git push origin :refs/tags/${{ github.event.release.tag_name }}
+
+
+  notify_failure:
+    name: Create Issue on Failure
+    if: ${{ failure() && github.event_name == 'schedule' }}
+    needs: [ build, scan ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub Issue
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.ORGANIZATION_TOKEN }}
+          script: |
+            const issueTitle = 'Scheduled Build Fail';
+            const issueBody = `Link: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
+            
+            // Set the owner and repo to exberry-io/docs
+            const owner = 'exberry-io';
+            const repo = 'docs';
+            
+            // Check if an open issue with the same title and label exists
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              labels: ['Bug'],
+            });
+            
+            const issueExists = issues.some(issue => issue.title === issueTitle);
+            
+            if (!issueExists) {
+              // Create a new issue
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title: issueTitle,
+                body: issueBody,
+                labels: ['Bug'],
+              });
+              console.log('Created a new issue for the failed scheduled build.');
+            } else {
+              console.log('An open issue for the failed scheduled build already exists.');
+            }
+
+  close_issue:
+    name: Close Issue on Success
+    if: ${{ success() && github.event_name == 'schedule' }}
+    needs: [ build, scan ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close GitHub Issue
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.ORGANIZATION_TOKEN }}
+          script: |
+            const issueTitle = 'Scheduled Build Fail';
+            const closeComment = `Closed due to success build`;
+
+            // Set the owner and repo to exberry-io/docs
+            const owner = 'exberry-io';
+            const repo = 'docs';
+
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              labels: ['Bug'],
+            });
+
+            if (issues.length === 0) {
+              console.log('No open issues to close');
+            } else {
+              for (const issue of issues) {
+                if (issue.title === issueTitle) {
+                  // Add a comment to the issue
+                  await github.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number: issue.number,
+                    body: closeComment,
+                  });
+                  // Close the issue
+                  await github.rest.issues.update({
+                    owner,
+                    repo,
+                    issue_number: issue.number,
+                    state: 'closed',
+                  });
+                  console.log(`Closed issue #${issue.number}`);
+                }
+              }
+            }


### PR DESCRIPTION
Link: https://github.com/exberry-io/docs/issues/1514

Behavior:
- In repos default branch is develop, meaning scheduler will build develop
- If scheduled build is failed it will create ticket - https://github.com/exberry-io/docs/issues/...
- If ticket was already created, new one will not be created (in scope of 1 repo)
- If build was successful previously opened issue about failed build will be closed
- If closed it will have "Closed due to success build: ${link}" comment
- Ticket name example "Scheduled Build Fail (iam-service)"
- Ticket has a link to the build and 'Bug' label
- Scheduled builds will not do deploys (push)

Note:
Each repo should be updated to have "scheduler" property, it is not inherited from the parent

iam-service PR: https://github.com/exberry-io/iam-service/pull/137

Example:

// Has intentionally broken test (ticket added)
https://github.com/exberry-io/iam-service/actions/runs/11237833810

// Made tests to work again (ticket closed)
https://github.com/exberry-io/iam-service/actions/runs/11237958557

// This task was created and then closed due to recovered build
https://github.com/exberry-io/docs/issues/2542