### PR TITLE
Allow multiple dockerfiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,20 +384,49 @@ jobs:
           echo "## Docker Images" >> $GITHUB_STEP_SUMMARY
           echo "| Image Name |" >> $GITHUB_STEP_SUMMARY
           echo "| - | ">> $GITHUB_STEP_SUMMARY
-          for directory in `find * -maxdepth 10 -mindepth 0 -type f -name 'Dockerfile' | xargs dirname`
+          for directory in $(find . -maxdepth 10 -type d)
           do
-            echo Run docker build for $directory
-            if [[ $directory == '.' ]]; then
-              image=${{ github.event.repository.name }}
-            else
-              image=$directory
-            fi
-            docker buildx build --push --platform linux/amd64,linux/arm64 \
-            -t ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.VERSION }} \
-            -t ghcr.io/${GITHUB_REPOSITORY}/$image:latest \
-            $directory
-            echo "| ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.VERSION }} |" >> $GITHUB_STEP_SUMMARY
-            IMAGES+=(\"ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.VERSION }}\")
+            # Find Dockerfiles inside this directory (non-recursive)
+            dockerfiles=$(find "$directory" -maxdepth 1 -type f \( -name 'Dockerfile' -o -name 'Dockerfile-*' \))
+          
+            # Skip if none found
+            [[ -z "$dockerfiles" ]] && continue
+          
+            for dockerfile in $dockerfiles
+            do
+              filename=$(basename "$dockerfile")
+          
+              echo "Run docker build for $dockerfile"
+          
+              # Extract suffix if present
+              if [[ "$filename" =~ ^Dockerfile-(.+)$ ]]; then
+                suffix="${BASH_REMATCH[1]}"
+              else
+                suffix=""
+              fi
+          
+              # Base image name
+              if [[ "$directory" == "." ]]; then
+                image="${{ github.event.repository.name }}"
+              else
+                image="$directory"
+              fi
+          
+              # Append suffix if it exists
+              if [[ -n "$suffix" ]]; then
+                image="${image}-${suffix}"
+              fi
+          
+              docker buildx build --push --platform linux/amd64,linux/arm64 \
+                -f "$dockerfile" \
+                -t ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.VERSION }} \
+                -t ghcr.io/${GITHUB_REPOSITORY}/$image:latest \
+                "$directory"
+          
+              echo "| ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.VERSION }} |" >> $GITHUB_STEP_SUMMARY
+              IMAGES+=("ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.VERSION }}")
+          
+            done
           done
           # Convert the array to a JSON string
           json_array="["

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,17 +415,19 @@ jobs:
           
               # Append suffix if it exists
               if [[ -n "$suffix" ]]; then
-                image="${image}-${suffix}"
+                tag="${{ env.VERSION }}-${suffix}"
+              else
+                tag="${{ env.VERSION }}"
               fi
           
               docker buildx build --push --platform linux/amd64,linux/arm64 \
                 -f "$dockerfile" \
-                -t ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.VERSION }} \
+                -t ghcr.io/${GITHUB_REPOSITORY}/$image:$tag \
                 -t ghcr.io/${GITHUB_REPOSITORY}/$image:latest \
                 "$directory"
           
-              echo "| ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.VERSION }} |" >> $GITHUB_STEP_SUMMARY
-              IMAGES+=("ghcr.io/${GITHUB_REPOSITORY}/$image:${{ env.VERSION }}")
+              echo "| ghcr.io/${GITHUB_REPOSITORY}/$image:$tag |" >> $GITHUB_STEP_SUMMARY
+              IMAGES+=("ghcr.io/${GITHUB_REPOSITORY}/$image:$tag")
           
             done
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,6 +386,7 @@ jobs:
           echo "| - | ">> $GITHUB_STEP_SUMMARY
           for directory in $(find . -maxdepth 10 -type d)
           do
+            clean_dir="${directory#./}"
             # Find Dockerfiles inside this directory (non-recursive)
             dockerfiles=$(find "$directory" -maxdepth 1 -type f \( -name 'Dockerfile' -o -name 'Dockerfile-*' \))
           
@@ -406,10 +407,10 @@ jobs:
               fi
           
               # Base image name
-              if [[ "$directory" == "." ]]; then
+              if [[ -z "$clean_dir" ]]; then
                 image="${{ github.event.repository.name }}"
               else
-                image="$directory"
+                image="$clean_dir"
               fi
           
               # Append suffix if it exists


### PR DESCRIPTION
all dockerfiles (such as `Dockerfile-[suffix]` will be processed in a directory so that the `[suffix]` is appended to the image's tag.