### PR TITLE
Set custom GH runner name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,10 +90,6 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Set up Maven
-        uses: stCarolas/setup-maven@v5
-        with:
-          maven-version: 3.9.6
-      - name: Prepare Maven
         run: cp build.settings.xml ~/.m2/settings.xml
       - name: Maven Build
         run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -Ddockerfile.skip=true -Dgithub.event.release.prerelease="${{ github.event.release.prerelease }}" -B -V -U
@@ -137,10 +133,6 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Set up Maven
-        uses: stCarolas/setup-maven@v5
-        with:
-          maven-version: 3.9.6
-      - name: Prepare Maven
         run: cp build.settings.xml ~/.m2/settings.xml
       - name: Maven Build
         run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -Ddockerfile.skip=true -Dgithub.event.release.prerelease="${{ github.event.release.prerelease }}" -B -V -U
@@ -192,10 +184,6 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Set up Maven
-        uses: stCarolas/setup-maven@v5
-        with:
-          maven-version: 3.9.6
-      - name: Prepare Maven
         run: cp build.settings.xml ~/.m2/settings.xml
       - name: Maven Build
         run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -Ddockerfile.skip=true -Dgithub.event.release.prerelease="${{ github.event.release.prerelease }}" -B -V -U
@@ -380,10 +368,6 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Set up Maven
-        uses: stCarolas/setup-maven@v5
-        with:
-          maven-version: 3.9.6
-      - name: Prepare Maven
         run: cp build.settings.xml ~/.m2/settings.xml
       - name: Deploy jars
         run: mvn clean deploy -DskipTests -Dgpg.skip=true -Drevision=${VERSION}-SNAPSHOT -B -V -U

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,10 @@ on:
         required: false
         default: false
         description: Include/Don't include Build and Push Debian Packages
+      runner:
+        required: false
+        type: string
+        default: ubuntu-latest
     secrets:
       ORGANIZATION_TOKEN:
         required: true
@@ -72,7 +76,7 @@ env:
 jobs:
   codacy-analysis-cli:
     name: Codacy Analysis CLI
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -106,7 +110,7 @@ jobs:
 
   build:
     name: Build (${{ matrix.arch }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     strategy:
       fail-fast: false
       matrix:
@@ -161,7 +165,7 @@ jobs:
 
   scan:
     name: Scan with Trivy
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     strategy:
       fail-fast: false
       matrix:
@@ -346,7 +350,7 @@ jobs:
       || github.event_name == 'release'
     name: Push artifacts
     needs: [ build, scan ]
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: jobName
         run: echo '# Push 🚀' >> $GITHUB_STEP_SUMMARY
@@ -543,7 +547,7 @@ jobs:
     name: Create Issue on Failure
     if: ${{ failure() && github.event_name == 'schedule' }}
     needs: [ build, scan ]
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Create GitHub Issue
         uses: actions/github-script@v6
@@ -587,7 +591,7 @@ jobs:
     name: Close Issue on Success
     if: ${{ success() && github.event_name == 'schedule' }}
     needs: [ build, scan ]
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Close GitHub Issue
         uses: actions/github-script@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,10 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Set up Maven
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: 3.9.6
+      - name: Prepare Maven
         run: cp build.settings.xml ~/.m2/settings.xml
       - name: Maven Build
         run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -Ddockerfile.skip=true -Dgithub.event.release.prerelease="${{ github.event.release.prerelease }}" -B -V -U
@@ -133,6 +137,10 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Set up Maven
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: 3.9.6
+      - name: Prepare Maven
         run: cp build.settings.xml ~/.m2/settings.xml
       - name: Maven Build
         run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -Ddockerfile.skip=true -Dgithub.event.release.prerelease="${{ github.event.release.prerelease }}" -B -V -U
@@ -184,6 +192,10 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Set up Maven
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: 3.9.6
+      - name: Prepare Maven
         run: cp build.settings.xml ~/.m2/settings.xml
       - name: Maven Build
         run: mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -Ddockerfile.skip=true -Dgithub.event.release.prerelease="${{ github.event.release.prerelease }}" -B -V -U
@@ -368,6 +380,10 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Set up Maven
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: 3.9.6
+      - name: Prepare Maven
         run: cp build.settings.xml ~/.m2/settings.xml
       - name: Deploy jars
         run: mvn clean deploy -DskipTests -Dgpg.skip=true -Drevision=${VERSION}-SNAPSHOT -B -V -U


### PR DESCRIPTION
By default (if you don't declare the runner), the CI uses the `ubuntu-latest` GH Runner.
If you declare the runner in the application's CI, it uses a custom one.

```yaml

    name: CI
    uses: scalecube/.github/.github/workflows/ci.yml@master
    secrets:
        //-//-//-//
    with:
      mvn-verify-opts: |
        [
         //-//-//-//
        ]
      force-publish: false
      tests: true
      runner: ${{ vars.GH_RUNNER_NAME }}
      ```
      
      Define the `GH_RUNNER_NAME` in the application repository Actions Variables (Settings-> Secrets and Variables -> Actions -> Repository Variables)